### PR TITLE
Query Execution Plan (EXPERIMENTAL)

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Yuki Furuyama
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ The syntax is case-insensitive.
 | Drop database |  | Not supported yet |
 | List tables | `SHOW TABLES;` | |
 | Show table schema | `SHOW CREATE TABLE <table>;` | |
-| Show columns | `DESCRIBE <table>;` | |
+| Show columns | `SHOW COLUMNS <table>;` | |
 | Create table | `CREATE TABLE ...;` | |
 | Change table schema | `ALTER TABLE ...;` | |
 | Delete table | `DROP TABLE ...;` | |
@@ -156,12 +156,12 @@ The syntax is case-insensitive.
 | Stale Read | | Not supported yet |
 | DML | `INSERT / UPDATE / DELETE ...;` | |
 | Partitioned DML | | Not supported yet |
+| Show Query Execution Plan | | `EXPLAIN SELECT ...;` |
 | Start Read-Write Transaction | `BEGIN (RW);` | |
 | Commit Read-Write Transaction | `COMMIT;` | |
 | Rollback Read-Write Transaction | `ROLLBACK;` | |
 | Start Read-Only Transaction | `BEGIN RO;` | |
 | End Read-Only Transaction | `CLOSE;` | |
-| Show Query Execution Plan | | Not supported yet |
 | Exit | `EXIT;` | |
 
 ## Customize prompt
@@ -230,5 +230,4 @@ $ PROJECT=${PROJECT_ID} INSTANCE=${INSTANCE_ID} DATABASE=${DATABASE_ID} CREDENTI
 ## TODO
 
 * STRUCT data type
-* EXPLAIN
 * show secondary index by "SHOW CREATE TABLE"

--- a/query_plan.go
+++ b/query_plan.go
@@ -38,6 +38,17 @@ func BuildQueryPlanTree(plan *pb.QueryPlan, idx int32) *Node {
 
 func (n *Node) Render() string {
 	tree := treeprint.New()
-	tree.AddBranch(n.PlanNode.DisplayName)
-	return tree.String()
+	renderTree(tree, n)
+	return "\n" + tree.String()
+}
+
+func renderTree(tree treeprint.Tree, node *Node) {
+	if len(node.Children) > 0 {
+		branch := tree.AddBranch(node.PlanNode.DisplayName)
+		for _, child := range node.Children {
+			renderTree(branch, child)
+		}
+	} else {
+		tree.AddNode(node.PlanNode.DisplayName)
+	}
 }

--- a/query_plan.go
+++ b/query_plan.go
@@ -55,36 +55,8 @@ func (n *Node) IsVisible() bool {
 
 func (n *Node) String() string {
 	operator := n.PlanNode.DisplayName
-	switch operator {
-	case "Distributed Union":
-		if typ, ok := getMetadataString(n, "call_type"); ok {
-			operator = fmt.Sprintf("%s %s", typ, operator)
-		}
-		return operator
-	case "Limit":
-		if typ, ok := getMetadataString(n, "limit_type"); ok {
-			operator = fmt.Sprintf("%s %s", typ, operator)
-		}
-		return operator
-	case "Scan":
-		if typ, ok := getMetadataString(n, "scan_type"); ok {
-			operator = typ
-		}
-		str := operator
-		if target, ok := getMetadataString(n, "scan_target"); ok {
-			str = fmt.Sprintf("%s: %s", str, target)
-		}
-		return str
-	case "Aggregate":
-		if n.PlanNode.ShortRepresentation != nil {
-			fmt.Println(n.PlanNode.ShortRepresentation.Description)
-		}
-
-		if typ, ok := getMetadataString(n, "iterator_type"); ok {
-			return fmt.Sprintf("%s %s", typ, operator)
-		}
-	}
-	return operator
+	metadata := getAllMetadataString(n)
+	return operator + " " + metadata
 }
 
 func getMetadataString(node *Node, key string) (string, bool) {
@@ -107,7 +79,7 @@ func getAllMetadataString(node *Node) string {
 	for k, v := range node.PlanNode.Metadata.Fields {
 		fields = append(fields, fmt.Sprintf("%s: %s", k, v.GetStringValue()))
 	}
-	return fmt.Sprintf(`"%s"`, strings.Join(fields, ", "))
+	return fmt.Sprintf(`(%s)`, strings.Join(fields, ", "))
 }
 
 func renderTree(tree treeprint.Tree, node *Node) {

--- a/query_plan.go
+++ b/query_plan.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"github.com/xlab/treeprint"
+	pb "google.golang.org/genproto/googleapis/spanner/v1"
+)
+
+type Node struct {
+	PlanNode *pb.PlanNode
+	Children []*Node
+}
+
+func BuildQueryPlanTree(plan *pb.QueryPlan, idx int32) *Node {
+	if len(plan.PlanNodes) == 0 {
+		// TODO
+		return &Node{}
+	}
+
+	nodeMap := map[int32]*pb.PlanNode{}
+	for _, node := range plan.PlanNodes {
+		nodeMap[node.Index] = node
+	}
+
+	root := &Node{
+		PlanNode: plan.PlanNodes[idx],
+		Children: make([]*Node, 0),
+	}
+	if root.PlanNode.ChildLinks != nil {
+		for _, childLink := range root.PlanNode.ChildLinks {
+			idx := childLink.ChildIndex
+			child := BuildQueryPlanTree(plan, idx)
+			root.Children = append(root.Children, child)
+		}
+	}
+
+	return root
+}
+
+func (n *Node) Render() string {
+	tree := treeprint.New()
+	tree.AddBranch(n.PlanNode.DisplayName)
+	return tree.String()
+}

--- a/statement.go
+++ b/statement.go
@@ -346,7 +346,7 @@ type ExplainStatement struct {
 func (s *ExplainStatement) Execute(session *Session) (*Result, error) {
 	return withElapsedTime(func() (*Result, error) {
 		result := &Result{
-			ColumnNames: []string{"Query_Execution_Plan"},
+			ColumnNames: []string{"Query_Execution_Plan (EXPERIMENTAL)"},
 			Rows:        make([]Row, 1),
 			IsMutation:  false,
 			Stats: Stats{

--- a/statement.go
+++ b/statement.go
@@ -63,7 +63,8 @@ var (
 	showDatabasesRe   = regexp.MustCompile(`(?is)^SHOW\s+DATABASES$`)
 	showCreateTableRe = regexp.MustCompile(`(?is)^SHOW\s+CREATE\s+TABLE\s+(.+)$`)
 	showTablesRe      = regexp.MustCompile(`(?is)^SHOW\s+TABLES$`)
-	describeTableRe   = regexp.MustCompile(`(?is)^DESC(?:RIBE)?\s+(.+)$`)
+	showColumnsRe     = regexp.MustCompile(`(?is)^(?:SHOW\s+COLUMNS|EXPLAIN|DESC(?:RIBE)?)\s+(.+)$`)
+	explainRe         = regexp.MustCompile(`(?is)^(?:EXPLAIN|DESC(?:RIBE)?)\s+(SELECT\s+.+)$`)
 )
 
 var (
@@ -104,9 +105,14 @@ func BuildStatement(input string) (Statement, error) {
 		}
 	} else if showTablesRe.MatchString(input) {
 		stmt = &ShowTablesStatement{}
-	} else if describeTableRe.MatchString(input) {
-		matched := describeTableRe.FindStringSubmatch(input)
-		stmt = &DescribeTableStatement{
+	} else if explainRe.MatchString(input) {
+		matched := explainRe.FindStringSubmatch(input)
+		stmt = &ExplainStatement{
+			text: matched[1],
+		}
+	} else if showColumnsRe.MatchString(input) {
+		matched := showColumnsRe.FindStringSubmatch(input)
+		stmt = &ShowColumnsStatement{
 			table: matched[1],
 		}
 	} else if insertRe.MatchString(input) || updateRe.MatchString(input) || deleteRe.MatchString(input) {
@@ -333,11 +339,38 @@ func (s *ShowTablesStatement) Execute(session *Session) (*Result, error) {
 	return result, nil
 }
 
-type DescribeTableStatement struct {
+type ExplainStatement struct {
+	text string
+}
+
+func (s *ExplainStatement) Execute(session *Session) (*Result, error) {
+	return withElapsedTime(func() (*Result, error) {
+		result := &Result{
+			ColumnNames: []string{"Query_Execution_Plan"},
+			Rows:        make([]Row, 1),
+			IsMutation:  false,
+			Stats: Stats{
+				AffectedRows: 1,
+			},
+		}
+
+		stmt := spanner.NewStatement(s.text)
+		_, err := session.client.Single().AnalyzeQuery(session.ctx, stmt)
+		if err != nil {
+			return nil, err
+		}
+
+		result.Rows[0] = Row{[]string{".\n|-test\n|-test\n"}}
+
+		return result, nil
+	})
+}
+
+type ShowColumnsStatement struct {
 	table string
 }
 
-func (s *DescribeTableStatement) Execute(session *Session) (*Result, error) {
+func (s *ShowColumnsStatement) Execute(session *Session) (*Result, error) {
 	query := SelectStatement{
 		text: fmt.Sprintf(`SELECT
   C.COLUMN_NAME as Field,

--- a/statement.go
+++ b/statement.go
@@ -355,12 +355,14 @@ func (s *ExplainStatement) Execute(session *Session) (*Result, error) {
 		}
 
 		stmt := spanner.NewStatement(s.text)
-		_, err := session.client.Single().AnalyzeQuery(session.ctx, stmt)
+		queryPlan, err := session.client.Single().AnalyzeQuery(session.ctx, stmt)
 		if err != nil {
 			return nil, err
 		}
 
-		result.Rows[0] = Row{[]string{".\n|-test\n|-test\n"}}
+		tree := BuildQueryPlanTree(queryPlan, 0)
+		rendered := tree.Render()
+		result.Rows[0] = Row{[]string{rendered}}
 
 		return result, nil
 	})

--- a/statement_test.go
+++ b/statement_test.go
@@ -33,8 +33,13 @@ func TestBuildStatement(t *testing.T) {
 		{"SHOW DATABASES", &ShowDatabasesStatement{}},
 		{"SHOW CREATE TABLE t1", &ShowCreateTableStatement{}},
 		{"SHOW TABLES", &ShowTablesStatement{}},
-		{"DESCRIBE t1", &DescribeTableStatement{}},
-		{"DESC t1", &DescribeTableStatement{}},
+		{"SHOW COLUMNS t1", &ShowColumnsStatement{}},
+		{"EXPLAIN t1", &ShowColumnsStatement{}},
+		{"DESCRIBE t1", &ShowColumnsStatement{}},
+		{"DESC t1", &ShowColumnsStatement{}},
+		{"EXPLAIN SELECT * FROM t1", &ExplainStatement{}},
+		{"DESCRIBE SELECT * FROM t1", &ExplainStatement{}},
+		{"DESC SELECT * FROM t1", &ExplainStatement{}},
 	}
 
 	for _, test := range validTests {


### PR DESCRIPTION
This is an experimental implementation for showing Query Execution Plan (`EXPLAIN`).
```
spanner> EXPLAIN SELECT a.AlbumTitle, s.SongName FROM Albums AS a HASH JOIN Songs AS s ON a.SingerId = s.SingerId AND a.AlbumId = s.AlbumId\G
*************************** 1. row ***************************
Query_Execution_Plan (EXPERIMENTAL): 
.
└── Distributed Union (subquery_cluster_node: 1)
    └── Serialize Result 
        └── Hash Join (join_type: INNER)
            ├── Distributed Union (subquery_cluster_node: 4, call_type: Local)
            │   └── Scan (Full scan: true, scan_target: Albums, scan_type: TableScan)
            └── Distributed Union (subquery_cluster_node: 9, call_type: Local)
                └── Scan (Full scan: true, scan_target: SongsBySingerAlbumSongNameDesc, scan_type: IndexScan)

1 rows in set (0.37 sec)
```