### PR TITLE
Warmup of spanner.ReadOnlyTransaction.

### DIFF
--- a/session.go
+++ b/session.go
@@ -70,7 +70,12 @@ func (s *Session) StartRwTxn(ctx context.Context, txn *spanner.ReadWriteTransact
 	return finish
 }
 
-func (s *Session) StartRoTxn(txn *spanner.ReadOnlyTransaction) {
+func (s *Session) StartRoTxn(ctx context.Context, txn *spanner.ReadOnlyTransaction) {
+
+	// Warmup of Transaction.
+	// If do not this operation, spanner.ReadOnlyTransaction does not open transaction up to the first query.
+	txn.Query(ctx, spanner.NewStatement("SELECT 1")).Stop()
+
 	s.roTxn = txn
 }
 

--- a/statement.go
+++ b/statement.go
@@ -630,7 +630,7 @@ func (s *BeginRoStatement) Execute(session *Session) (*Result, error) {
 	if s.Staleness != time.Duration(0) {
 		txn = txn.WithTimestampBound(spanner.ExactStaleness(s.Staleness))
 	}
-	session.StartRoTxn(txn)
+	session.StartRoTxn(session.ctx, txn)
 
 	return &Result{
 		ColumnNames: make([]string, 0),


### PR DESCRIPTION
After executing the `BEGIN RO` command, when referring to the data written by the ReadWrite transaction, is it more intuitive to read the data of the timestamp that opened the ReadOnly transaction?

`spanner.ReadOnlyTrasaction` is open of actual transaction at fist query.
This PR is force open of transaction at `Session.StartRoTxn` time.

Look at this.

*This has been initialized in advance
```
CREATE TABLE test (
    ID INT64 NOT NULL,
    Val STRING(MAX) NOT NULL,
) PRIMARY KEY(ID)

INSERT INTO test(ID, Val) VALUES (1, "1")
```


```
# client 1
$ spanner-cli -p sandbox-230212 -i default -d mydb
Connected.
spanner> BEGIN RO;
Query OK, 0 rows affected (0.00 sec)

# client 2
$ spanner-cli -p sandbox-230212 -i default -d mydb
Connected.
spanner> BEGIN RW;
Query OK, 0 rows affected (0.06 sec)

spanner(rw txn)> UPDATE test SET Val="2" WHERE ID=1;
Query OK, 1 rows affected (0.02 sec)

spanner(rw txn)> COMMIT;
Query OK, 0 rows affected (0.06 sec)

# client 1
spanner(ro txn)> SELECT * FROM test;
+----+-----+
| ID | Val |
+----+-----+
| 1  | 2   | // want: Val=1 got:Val=2
+----+-----+
1 rows in set (2.47 msecs)
```